### PR TITLE
Update MessageDialog.cs

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -72,7 +72,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
             KeyEventHandler escapeKeyHandler = null;
 
-            Action cleanUpHandlers = null;
+            Action cleanUpHandlers = new Action(() => { });
 
             var cancellationTokenRegistration = DialogSettings.CancellationToken.Register(() =>
             {


### PR DESCRIPTION
## What changed?

Assign empty lambda vs null to cleanUpHandlers() to fix issue where early cancellation causes null reference exception
